### PR TITLE
Send the DownloadItem in the payload for "download-completed" event

### DIFF
--- a/electron-observer.js
+++ b/electron-observer.js
@@ -18,12 +18,11 @@ function addSession(session) {
 }
 
 function sessionWillDownload(event, download) {
-  download.once("done", downloadDone)
-}
-
-function downloadDone(event, state) {
-  if (state != "completed") return
-  observer.emit("download-completed", event.sender)
+  download.once("done", (event, state) => {
+    if (state == "completed") {
+      observer.emit("download-completed", download)
+    }
+  })
 }
 
 module.exports = observer


### PR DESCRIPTION
The `event.sender` is now undefined, so let's send the `download` object as a payload. It is needed to extract the save path and pass it to the quarantine function.